### PR TITLE
OTP verification completed

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+### Application Config ###
+src/main/resources/application.properties
+src/main/resources/application.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 

--- a/backend/src/main/java/com/lopsie/portfolio/controller/AuthController.java
+++ b/backend/src/main/java/com/lopsie/portfolio/controller/AuthController.java
@@ -2,9 +2,11 @@ package com.lopsie.portfolio.controller;
 
 import com.lopsie.portfolio.dto.AuthResponse; // We will create this DTO
 import com.lopsie.portfolio.dto.LoginRequest; // We will create this DTO
+import com.lopsie.portfolio.dto.OtpRequest;
 import com.lopsie.portfolio.dto.RegisterRequest; // We will create this DTO
 import com.lopsie.portfolio.entity.User;
 import com.lopsie.portfolio.service.JwtService; // We will create this service
+import com.lopsie.portfolio.service.OtpService;
 import com.lopsie.portfolio.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,11 +23,13 @@ public class AuthController {
     private final UserService userService;
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
+    private final OtpService otpService;
 
-    public AuthController(UserService userService, JwtService jwtService, AuthenticationManager authenticationManager) {
+    public AuthController(UserService userService, JwtService jwtService, AuthenticationManager authenticationManager, OtpService otpService) {
         this.userService = userService;
         this.jwtService = jwtService;
         this.authenticationManager = authenticationManager;
+        this.otpService = otpService;
     }
 
     /**
@@ -44,7 +48,7 @@ public class AuthController {
             // The service will handle hashing and saving
             userService.registerUser(newUser);
 
-            return ResponseEntity.ok("User registered successfully!");
+            return ResponseEntity.ok("Registration successful. OTP sent to email.");
         } catch (IllegalStateException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
@@ -67,6 +71,14 @@ public class AuthController {
 
         // Return the token in the response
         return ResponseEntity.ok(new AuthResponse(token));
+    }
+
+
+    @PostMapping("/verify-otp")
+    public ResponseEntity<String> verifyOtp(@RequestBody OtpRequest req) {
+        boolean ok = otpService.verifyOtpAndActivate(req.getEmail(), req.getOtp());
+        if (ok) return ResponseEntity.ok("Account verified successfully.");
+        else return ResponseEntity.badRequest().body("Invalid or expired OTP.");
     }
 
     @GetMapping("/hello")

--- a/backend/src/main/java/com/lopsie/portfolio/dto/OtpRequest.java
+++ b/backend/src/main/java/com/lopsie/portfolio/dto/OtpRequest.java
@@ -1,0 +1,11 @@
+package com.lopsie.portfolio.dto;
+
+public class OtpRequest {
+    private String email;
+    private String otp;
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getOtp() { return otp; }
+    public void setOtp(String otp) { this.otp = otp; }
+}

--- a/backend/src/main/java/com/lopsie/portfolio/entity/Otp.java
+++ b/backend/src/main/java/com/lopsie/portfolio/entity/Otp.java
@@ -1,0 +1,36 @@
+package com.lopsie.portfolio.entity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "otps")
+public class Otp {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryTime;
+
+    public Otp() {}
+
+    public Otp(String email, String code, LocalDateTime expiryTime) {
+        this.email = email;
+        this.code = code;
+        this.expiryTime = expiryTime;
+    }
+
+    public Long getId() { return id; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public LocalDateTime getExpiryTime() { return expiryTime; }
+    public void setExpiryTime(LocalDateTime expiryTime) { this.expiryTime = expiryTime; }
+}

--- a/backend/src/main/java/com/lopsie/portfolio/entity/User.java
+++ b/backend/src/main/java/com/lopsie/portfolio/entity/User.java
@@ -22,6 +22,9 @@ public class User implements UserDetails { // <-- IMPLEMENT UserDetails
 
     private String password; // This will be the hashed password
 
+    private boolean enabled = false;
+
+
     // --- UserDetails Methods ---
 
     @Override
@@ -53,7 +56,7 @@ public class User implements UserDetails { // <-- IMPLEMENT UserDetails
 
     @Override
     public boolean isEnabled() {
-        return true; // Account is always enabled
+        return this.enabled; // Account is always enabled
     }
 
     // --- Your existing Getters and Setters ---
@@ -66,4 +69,14 @@ public class User implements UserDetails { // <-- IMPLEMENT UserDetails
     @Override
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
+    public boolean getEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+
+    // add field
+
+// modify isEnabled()
+
+
+
 }

--- a/backend/src/main/java/com/lopsie/portfolio/repository/OtpRepository.java
+++ b/backend/src/main/java/com/lopsie/portfolio/repository/OtpRepository.java
@@ -1,0 +1,12 @@
+package com.lopsie.portfolio.repository;
+
+import com.lopsie.portfolio.entity.Otp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import java.util.List;
+
+public interface OtpRepository extends JpaRepository<Otp, Long> {
+    Optional<Otp> findByEmailAndCode(String email, String code);
+    List<Otp> findByEmail(String email);
+    void deleteByEmail(String email);
+}

--- a/backend/src/main/java/com/lopsie/portfolio/service/EmailService.java
+++ b/backend/src/main/java/com/lopsie/portfolio/service/EmailService.java
@@ -1,0 +1,19 @@
+package com.lopsie.portfolio.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+    private final JavaMailSender mailSender;
+    public EmailService(JavaMailSender mailSender) { this.mailSender = mailSender; }
+
+    public void sendOtpEmail(String to, String otp) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Your AI Portfolio - Registration OTP");
+        message.setText("Your verification code is: " + otp + "\nIt will expire in 5 minutes.");
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/java/com/lopsie/portfolio/service/OtpService.java
+++ b/backend/src/main/java/com/lopsie/portfolio/service/OtpService.java
@@ -1,0 +1,68 @@
+package com.lopsie.portfolio.service;
+
+import com.lopsie.portfolio.entity.Otp;
+import com.lopsie.portfolio.entity.User;
+import com.lopsie.portfolio.repository.OtpRepository;
+import com.lopsie.portfolio.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class OtpService {
+
+    private final OtpRepository otpRepository;
+    private final EmailService emailService;
+    private final UserRepository userRepository;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public OtpService(OtpRepository otpRepository, EmailService emailService, UserRepository userRepository) {
+        this.otpRepository = otpRepository;
+        this.emailService = emailService;
+        this.userRepository = userRepository;
+    }
+
+    public void generateAndSendOtp(String email) {
+        // remove existing
+        otpRepository.deleteByEmail(email);
+
+        int code = secureRandom.nextInt(900_000) + 100_000; // ensures 6 digits
+        String otpCode = String.format("%06d", code);
+        LocalDateTime expiry = LocalDateTime.now().plusMinutes(5);
+
+        Otp otp = new Otp(email, otpCode, expiry);
+        otpRepository.save(otp);
+
+        emailService.sendOtpEmail(email, otpCode);
+    }
+
+    @Transactional
+    public boolean verifyOtpAndActivate(String email, String code) {
+        Optional<Otp> rec = otpRepository.findByEmailAndCode(email, code);
+        if (rec.isEmpty()) return false;
+        Otp otp = rec.get();
+        if (otp.getExpiryTime().isBefore(LocalDateTime.now())) {
+            otpRepository.deleteByEmail(email);
+            return false;
+        }
+        // activate user
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalStateException("User not found"));
+        user.setEnabled(true);
+        userRepository.save(user);
+
+        // delete used otp
+        otpRepository.deleteByEmail(email);
+        return true;
+    }
+
+    // Optional cleanup method (can be scheduled)
+    public void deleteExpiredOtps() {
+        otpRepository.findAll()
+                .stream()
+                .filter(o -> o.getExpiryTime().isBefore(LocalDateTime.now()))
+                .forEach(o -> otpRepository.delete(o));
+    }
+}


### PR DESCRIPTION
Hi, I’ve added OTP-based email verification for user registration. Here’s a summary of the changes:

What’s new:

Otp entity, OtpRepository, OtpRequest DTO

EmailService for sending OTPs

OtpService for generating, validating, and deleting OTPs

What’s modified:

User.java → added enabled flag to block login until OTP verification

UserService.java → disabled user on registration and called OtpService

AuthController.java → updated /register endpoint to indicate OTP sent, added /verify-otp endpoint

SecurityConfig.java → verified PasswordEncoder and authentication setup

How it works:

On registration, a 6-digit OTP is generated and emailed

User verifies OTP via /verify-otp; account is activated if valid and unexpired (5 minutes)

Invalid or expired OTP is rejected

Login is blocked until verification

Testing:

Registration → OTP email sent

OTP verification → account enabled

Invalid/expired OTP → rejected

Note:

My local application.properties file (with PostgreSQL and SMTP credentials) is not included in this PR. You’ll need to configure your own credentials to test OTP emails.